### PR TITLE
fix: add id prop to InteriorLeftNavList

### DIFF
--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -66,7 +66,6 @@ export default class InteriorLeftNav extends Component {
         {...child.props}
         key={key}
         ref={key}
-        id={key}
         onListClick={this.handleListClick}
         onItemClick={this.handleItemClick}
         activeHref={this.state.activeHref}

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList.js
@@ -67,6 +67,7 @@ export default class InteriorLeftNavList extends Component {
       children,
       className,
       iconDescription,
+      id,
       onListClick, // eslint-disable-line no-unused-vars
       onItemClick, // eslint-disable-line no-unused-vars
       activeHref, // eslint-disable-line no-unused-vars
@@ -92,7 +93,7 @@ export default class InteriorLeftNavList extends Component {
         onClick={this.toggle}
         onKeyPress={this.toggle}
         role="menuitem">
-        <div className="left-nav-list__item-link">
+        <div className="left-nav-list__item-link" id={id}>
           {title}
           <div className="left-nav-list__item-icon">
             <Icon


### PR DESCRIPTION
This PR adds the `id` prop (not auto generated) to the `div` created for `InteriorLeftNavList` component.  Previously the `id` was auto generated in `InteriorLeftNav` but was not actually put on the element.