### PR TITLE
feat(tags): multiple states for isEditable

### DIFF
--- a/src/components/TagList/TagList-story.js
+++ b/src/components/TagList/TagList-story.js
@@ -68,18 +68,31 @@ storiesOf('TagList', module)
     () => <TagList {...tagListEvents} />
   )
   .addWithInfo(
-    'Display All Editable',
+    'Display All Editable Always',
     `
     A TagList is used to manage multiple tags at once. The example below shows how the TagList component can be used in an editable state.
   `,
-    () => <TagList {...tagListEvents} numTagsDisplayed={3} isEditable />
+    () => (
+      <TagList {...tagListEvents} numTagsDisplayed={3} isEditable="always" />
+    )
+  )
+  .addWithInfo(
+    'Display All Editable Only On Hover',
+    `
+    A TagList is used to manage multiple tags at once. The example below shows how the TagList component can be used in an editable state, only when the TagList is hovered.
+  `,
+    () => (
+      <TagList {...tagListEvents} numTagsDisplayed={3} isEditable="onHover" />
+    )
   )
   .addWithInfo(
     'Display 1 Editable',
     `
     A TagList is used to manage multiple tags at once. The example below shows how the TagList component can be used to condense a list.
   `,
-    () => <TagList {...tagListEvents} numTagsDisplayed={1} isEditable />
+    () => (
+      <TagList {...tagListEvents} numTagsDisplayed={1} isEditable="always" />
+    )
   )
   .addWithInfo(
     'Fully Condensed',

--- a/src/components/TagList/TagList-test.js
+++ b/src/components/TagList/TagList-test.js
@@ -54,14 +54,29 @@ describe('TagList', () => {
     expect(wrapper.find(Icon)).toHaveLength(1);
   });
 
-  it('should display edit state when isEditable is true', () => {
+  it('should display edit state when isEditable is always', () => {
     mockProps = {
       ...mockProps,
-      isEditable: true,
+      isEditable: 'always',
       onIconClick: onIconClickMock,
     };
 
     const wrapper = shallow(<TagList {...mockProps} />);
+    expect(wrapper.find(Icon)).toHaveLength(1);
+    wrapper.find(Icon).simulate('click');
+    expect(onIconClickMock).toHaveBeenCalled;
+  });
+
+  it('should display edit state only on hover when isEditable is onHover', () => {
+    mockProps = {
+      ...mockProps,
+      isEditable: 'onHover',
+      onIconClick: onIconClickMock,
+    };
+
+    const wrapper = shallow(<TagList {...mockProps} />);
+    expect(wrapper.find(Icon)).toHaveLength(0);
+    wrapper.find('div').simulate('mouseenter');
     expect(wrapper.find(Icon)).toHaveLength(1);
     wrapper.find(Icon).simulate('click');
     expect(onIconClickMock).toHaveBeenCalled;

--- a/src/components/TagList/TagList.js
+++ b/src/components/TagList/TagList.js
@@ -6,6 +6,10 @@ import { Icon } from 'carbon-components-react';
 import Tag from '../Tag';
 
 export default class TagList extends Component {
+  state = {
+    showEditIcon: false,
+  };
+
   static propTypes = {
     numTagsDisplayed: PropTypes.number.isRequired,
     tags: PropTypes.arrayOf(
@@ -24,14 +28,31 @@ export default class TagList extends Component {
       })
     ).isRequired,
     className: PropTypes.string,
-    isEditable: PropTypes.bool,
+    isEditable: PropTypes.oneOf(['always', 'never', 'onHover']),
     onIconClick: PropTypes.func,
     counterTagClassName: PropTypes.string,
   };
 
   static defaultProps = {
-    isEditable: false,
+    isEditable: 'never',
     numTagsDisplayed: 3,
+  };
+
+  toggleEditIconShow = () => {
+    this.setState({
+      showEditIcon: true,
+    });
+  };
+
+  toggleEditIconHide = () => {
+    this.setState({
+      showEditIcon: false,
+    });
+  };
+
+  handleOnIconClick = evt => {
+    evt.stopPropagation();
+    if (this.props.onIconClick) this.props.onIconClick();
   };
 
   render() {
@@ -60,7 +81,15 @@ export default class TagList extends Component {
     );
 
     return (
-      <div className={tagListClassNames} {...rest}>
+      <div
+        className={tagListClassNames}
+        {...rest}
+        onMouseEnter={
+          isEditable === 'onHover' ? this.toggleEditIconShow : undefined
+        }
+        onMouseLeave={
+          isEditable === 'onHover' ? this.toggleEditIconHide : undefined
+        }>
         {displayList.map(tag => (
           <Tag
             key={tag.name}
@@ -95,8 +124,10 @@ export default class TagList extends Component {
             {tags.length}
           </Tag>
         )}
-        {isEditable && (
-          <button className="bx--tag-list--edit--button" onClick={onIconClick}>
+        {isEditable === 'always' && (
+          <button
+            className="bx--tag-list--edit--button"
+            onClick={this.handleOnIconClick}>
             <Icon
               name="edit--glyph"
               className="bx--tag-list--edit--icon"
@@ -105,6 +136,19 @@ export default class TagList extends Component {
             />
           </button>
         )}
+        {isEditable === 'onHover' &&
+          this.state.showEditIcon && (
+            <button
+              className="bx--tag-list--edit--button"
+              onClick={this.handleOnIconClick}>
+              <Icon
+                name="edit--glyph"
+                className="bx--tag-list--edit--icon"
+                title="edit icon"
+                description="edit icon that can trigger an editable state for the tags in list"
+              />
+            </button>
+          )}
       </div>
     );
   }


### PR DESCRIPTION
- Three states for `isEditable`: `always`, `never`, or `onHover`
- Stop propagation of event when clicking edit icon
