### PR TITLE
fix(tag-list): expose max-characters prop on tag-list component

### DIFF
--- a/src/components/CloudHeader/CloudHeaderLogo.js
+++ b/src/components/CloudHeader/CloudHeaderLogo.js
@@ -23,7 +23,8 @@ const CloudHeaderLogo = props => {
         <div className="bx--cloud-header-brand__icon">{children}</div>
       ) : null}
       <h4 className="bx--cloud-header-brand__text">
-        {companyName}&nbsp;
+        {companyName}
+        &nbsp;
         <span>{productName}</span>
       </h4>
     </a>

--- a/src/components/TagList/TagList-story.js
+++ b/src/components/TagList/TagList-story.js
@@ -102,6 +102,13 @@ storiesOf('TagList', module)
     () => <TagList {...tagListEvents} numTagsDisplayed={0} />
   )
   .addWithInfo(
+    'Display all tags with a maximum of 5 characters',
+    `
+    A TagList is used to manage multiple tags at once. The example below shows how the TagList component can be used with a maximum number of characters per tag.
+  `,
+    () => <TagList {...tagListEvents} numTagsDisplayed={3} maxCharacters={5} />
+  )
+  .addWithInfo(
     'Display 2 Editable with Tag Properties Applied',
     `
     A TagList is used to manage multiple tags at once. The example below shows how the TagList component can be used to condense a list.

--- a/src/components/TagList/TagList.js
+++ b/src/components/TagList/TagList.js
@@ -31,6 +31,7 @@ export default class TagList extends Component {
     isEditable: PropTypes.oneOf(['always', 'never', 'on-hover']),
     onIconClick: PropTypes.func,
     counterTagClassName: PropTypes.string,
+    maxCharacters: PropTypes.number,
   };
 
   static defaultProps = {
@@ -63,6 +64,7 @@ export default class TagList extends Component {
       onIconClick,
       tags,
       counterTagClassName,
+      maxCharacters,
       ...rest
     } = this.props;
 
@@ -96,7 +98,8 @@ export default class TagList extends Component {
             className="bx--tag-list--tag"
             type={tag.type}
             title={tag.name}
-            {...tag.otherProps}>
+            {...tag.otherProps}
+            {...{ maxCharacters }}>
             {tag.name}
           </Tag>
         ))}

--- a/src/components/TagList/TagList.js
+++ b/src/components/TagList/TagList.js
@@ -99,7 +99,7 @@ export default class TagList extends Component {
             type={tag.type}
             title={tag.name}
             {...tag.otherProps}
-            {...{ maxCharacters }}>
+            {...(maxCharacters ? { maxCharacters } : {})}>
             {tag.name}
           </Tag>
         ))}

--- a/src/components/TagList/TagList.js
+++ b/src/components/TagList/TagList.js
@@ -98,8 +98,8 @@ export default class TagList extends Component {
             className="bx--tag-list--tag"
             type={tag.type}
             title={tag.name}
-            {...tag.otherProps}
-            {...(maxCharacters ? { maxCharacters } : {})}>
+            maxCharacters={maxCharacters}
+            {...tag.otherProps}>
             {tag.name}
           </Tag>
         ))}


### PR DESCRIPTION
Minor fix to allow for a `maxCharacters` prop on the `TagList` component. 

#### Changelog

**New**

- Exposes a `maxCharacters` prop on the `TagList` component to allow developers to pass in a single prop to set `maxCharacters` on all tags, as opposed to setting max characters on every tag. 
