### PR TITLE
fix(filters): fix type check on tabIndex

### DIFF
--- a/src/components/Checkbox/Checkbox-test.js
+++ b/src/components/Checkbox/Checkbox-test.js
@@ -57,7 +57,7 @@ describe('Checkbox', () => {
     );
 
     expect(wrapper.find('MouseOverTooltip').exists()).toBe(true);
-    expect(wrapper.find('MouseOverTooltip').prop('tabIndex')).toEqual('-1');
+    expect(wrapper.find('MouseOverTooltip').prop('tabIndex')).toEqual(-1);
     expect(wrapper.find('MouseOverTooltip').prop('triggerText')).toEqual(
       'testingLabel'
     );
@@ -75,7 +75,7 @@ describe('Checkbox', () => {
     wrapper.setProps({ hasGroups: true });
     wrapper.update();
 
-    expect(wrapper.find('MouseOverTooltip').prop('tabIndex')).toEqual('0');
+    expect(wrapper.find('MouseOverTooltip').prop('tabIndex')).toEqual(0);
     expect(wrapper.find('CheckBoxIcon').exists()).toBe(true);
   });
 

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -55,7 +55,7 @@ const Checkbox = ({
             <MouseOverTooltip
               className="bx--checkbox--tooltip"
               showIcon={false}
-              tabIndex={hasGroups ? '0' : '-1'}
+              tabIndex={hasGroups ? 0 : -1}
               triggerText={labelText}>
               {tooltipText}
             </MouseOverTooltip>


### PR DESCRIPTION
To fix `Warning: Failed prop type: Invalid prop `tabIndex` of type `string` supplied to `MouseOverTooltip`, expected `number`.`