### PR TITLE
remove nav presentation role

### DIFF
--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -122,7 +122,6 @@ export default class InteriorLeftNav extends Component {
 
     return (
       <nav
-        role="presentation"
         tabIndex={-1}
         aria-label="Interior Left Navigation"
         className={classNames}


### PR DESCRIPTION
According to the W3C recommendation [here](https://www.w3.org/TR/html5/sections.html#the-nav-element) the `nav` element shouldn't have a set role attribute. It is currently throwing a11y violations in DAP for ibmcloud/account. This PR removes the `role="presentation"` attribute and allows the nav to fallback to its default navigation role.