### PR TITLE
Improve InteriorLeftNav structure towards a11y compliance

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "promise": "^8.0.1",
     "react": "^16.1.0",
     "react-dom": "^16.1.0",
+    "react-router-dom": "^4.3.1",
     "rimraf": "^2.6.2",
     "sass-loader": "^6.0.6",
     "semantic-release": "^15.0.1",

--- a/src/components/InteriorLeftNav/InteriorLeftNav-story.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav-story.js
@@ -6,6 +6,8 @@ import InteriorLeftNavItem from '../InteriorLeftNavItem';
 import InteriorLeftNavList from '../InteriorLeftNavList';
 import { Icon } from 'carbon-components-react';
 
+import { BrowserRouter as Router, Route, Link } from 'react-router-dom';
+
 storiesOf('InteriorLeftNav', module)
   .addWithInfo(
     'Default',
@@ -92,4 +94,39 @@ storiesOf('InteriorLeftNav', module)
         </InteriorLeftNav>
       );
     }
-  );
+  )
+  .add('With Router', () => {
+    const Index = () => <h2>Home</h2>;
+    const About = () => <h2>About</h2>;
+    const Users = () => <h2>Users</h2>;
+    return (
+      <Router>
+        <div>
+          <InteriorLeftNav>
+            <InteriorLeftNavHeader>Product</InteriorLeftNavHeader>
+            <InteriorLeftNavList open title="Example Item 1">
+              <InteriorLeftNavItem href="/">
+                <Link to="/">Home</Link>
+              </InteriorLeftNavItem>
+              <InteriorLeftNavItem href="/about">
+                <Link to="/about">About</Link>
+              </InteriorLeftNavItem>
+              <InteriorLeftNavItem href="/users">
+                <Link to="/users">Users</Link>
+              </InteriorLeftNavItem>
+            </InteriorLeftNavList>
+            <InteriorLeftNavItem href="/">
+              <Link to="/">Home</Link>
+            </InteriorLeftNavItem>
+            <InteriorLeftNavItem href="/about">
+              <Link to="/about">About</Link>
+            </InteriorLeftNavItem>
+          </InteriorLeftNav>
+
+          <Route path="/" exact component={Index} />
+          <Route path="/about/" component={About} />
+          <Route path="/users/" component={Users} />
+        </div>
+      </Router>
+    );
+  });

--- a/src/components/InteriorLeftNav/InteriorLeftNav-test.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav-test.js
@@ -82,19 +82,13 @@ describe('InteriorLeftNav', () => {
 
     it('handles item click as expected', () => {
       interiorLeftNav.setState({ activeHref: '#' });
-      item.simulate('click');
+      item.find('a').simulate('click');
       expect(interiorLeftNav.state().activeHref).toEqual('#first');
     });
 
     it('should set activeHref to items href on Enter', () => {
       interiorLeftNav.setState({ activeHref: '#' });
-      item.simulate('keypress', { which: 13 });
-      expect(interiorLeftNav.state().activeHref).toEqual('#first');
-    });
-
-    it('should set activeHref to items href on Space', () => {
-      interiorLeftNav.setState({ activeHref: '#' });
-      item.simulate('keypress', { which: 32 });
+      item.find('a').simulate('keypress', { which: 13 });
       expect(interiorLeftNav.state().activeHref).toEqual('#first');
     });
 

--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -127,7 +127,7 @@ export default class InteriorLeftNav extends Component {
         className={classNames}
         onClick={!this.state.open ? this.toggle : () => {}}
         {...other}>
-        <ul key="main_list" className="left-nav-list" role="menubar">
+        <ul key="main_list" className="left-nav-list">
           {newChildren}
         </ul>
         <button

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem-test.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem-test.js
@@ -73,17 +73,17 @@ describe('InteriorLeftNavItem', () => {
     );
 
     it('handles click to leftNavList as expected', () => {
-      wrapper.simulate('click');
+      wrapper.find('a').simulate('click');
       expect(onClick).toBeCalled();
     });
 
     it('should toggle the leftNavList on Enter', () => {
-      wrapper.simulate('keypress', { which: 13 });
+      wrapper.find('a').simulate('keypress', { which: 13 });
       expect(onClick).toBeCalled();
     });
 
     it('should toggle the leftNavList on Space', () => {
-      wrapper.simulate('keypress', { which: 32 });
+      wrapper.find('a').simulate('keypress', { which: 32 });
       expect(onClick).toBeCalled();
     });
   });

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
@@ -8,6 +8,7 @@ const newChild = (children, onFocus, onClick, href) => {
     className: 'left-nav-list__item-link',
     onFocus: onFocus,
     onClick: evt => onClick(evt, href),
+    onKeyPress: evt => onClick(evt, href),
   });
 };
 

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
@@ -2,11 +2,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const newChild = (children, tabIndex) => {
+const newChild = (children, onFocus, onBlur) => {
   const child = React.Children.only(children);
   return React.cloneElement(React.Children.only(child), {
-    tabIndex,
     className: 'left-nav-list__item-link',
+    onFocus: onFocus,
+    onBlur: onBlur,
   });
 };
 
@@ -18,6 +19,8 @@ const InteriorLeftNavItem = ({
   tabIndex,
   children,
   label,
+  onFocus,
+  onBlur,
   ...other
 }) => {
   const classNames = classnames('left-nav-list__item', className, {
@@ -25,20 +28,11 @@ const InteriorLeftNavItem = ({
   });
 
   return (
-    <li
-      tabIndex={children ? -1 : tabIndex}
-      role="menuitem"
-      className={classNames}
-      onClick={evt => onClick(evt, href)}
-      onKeyPress={evt => onClick(evt, href)}
-      {...other}>
+    <li className={classNames} {...other}>
       {children ? (
-        newChild(children, tabIndex)
+        newChild(children, onFocus, onBlur)
       ) : (
-        <a
-          className="left-nav-list__item-link"
-          href={href}
-          tabIndex={children ? tabIndex : -1}>
+        <a className="left-nav-list__item-link" href={href}>
           {label}
         </a>
       )}

--- a/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
+++ b/src/components/InteriorLeftNavItem/InteriorLeftNavItem.js
@@ -2,12 +2,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-const newChild = (children, onFocus, onBlur) => {
+const newChild = (children, onFocus, onClick, href) => {
   const child = React.Children.only(children);
   return React.cloneElement(React.Children.only(child), {
     className: 'left-nav-list__item-link',
     onFocus: onFocus,
-    onBlur: onBlur,
+    onClick: evt => onClick(evt, href),
   });
 };
 
@@ -20,7 +20,6 @@ const InteriorLeftNavItem = ({
   children,
   label,
   onFocus,
-  onBlur,
   ...other
 }) => {
   const classNames = classnames('left-nav-list__item', className, {
@@ -30,9 +29,12 @@ const InteriorLeftNavItem = ({
   return (
     <li className={classNames} {...other}>
       {children ? (
-        newChild(children, onFocus, onBlur)
+        newChild(children, onFocus, onClick, href)
       ) : (
-        <a className="left-nav-list__item-link" href={href}>
+        <a
+          className="left-nav-list__item-link"
+          href={href}
+          onClick={evt => onClick(evt, href)}>
           {label}
         </a>
       )}

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList.js
@@ -56,6 +56,8 @@ export default class InteriorLeftNavList extends Component {
         onClick={onItemClick}
         activeHref={activeHref}
         tabIndex={this.state.open ? 0 : -1}
+        onFocus={() => this.setState({ open: true })}
+        onBlur={() => this.setState({ open: false })}
       />
     );
   };
@@ -91,8 +93,7 @@ export default class InteriorLeftNavList extends Component {
         className={classNames}
         tabIndex={tabIndex}
         onClick={this.toggle}
-        onKeyPress={this.toggle}
-        role="menuitem">
+        onKeyPress={this.toggle}>
         <div className="left-nav-list__item-link" id={id}>
           {title}
           <div className="left-nav-list__item-icon">
@@ -103,11 +104,7 @@ export default class InteriorLeftNavList extends Component {
             />
           </div>
         </div>
-        <ul
-          role="menu"
-          className="left-nav-list left-nav-list--nested"
-          aria-label={title}
-          aria-hidden>
+        <ul className="left-nav-list left-nav-list--nested" aria-label={title}>
           {newChildren}
         </ul>
       </li>

--- a/src/components/InteriorLeftNavList/InteriorLeftNavList.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList.js
@@ -57,7 +57,6 @@ export default class InteriorLeftNavList extends Component {
         activeHref={activeHref}
         tabIndex={this.state.open ? 0 : -1}
         onFocus={() => this.setState({ open: true })}
-        onBlur={() => this.setState({ open: false })}
       />
     );
   };


### PR DESCRIPTION
#### Changelog

**New**

- Storybook entry showcasing InteriorLeftNav usage with React-Router
- Allow the nested list "drawers" to open when one of their children is focused - ie: tabbing into the list from above or below it.

**Changed**

- Replace click and keypress handlers on `li` elements with the same handlers on their child anchor tags - **fixes a11y DAP violation.**

**Removed**

- Removed incomplete aria-role attributes "menu" and "menuitem" that were throwing DAP violations since their implementation was incomplete - **fixes a11y DAP violation.**
- Removed the dynamic assignments of tab-index values in favor of a static list of tabbable and always aria-visible links. **fixes a11y DAP violation.**
