### PR TITLE
feat: update tag list design so clicking anywhere opens edit tag modal

### DIFF
--- a/src/components/TagList/TagList.js
+++ b/src/components/TagList/TagList.js
@@ -162,6 +162,7 @@ export default class TagList extends Component {
     return (
       <div
         className={tagListClassNames}
+        onClick={this.handleOnIconClick}
         {...rest}
         onMouseEnter={
           isEditable === 'on-hover' ? this.toggleEditIconShow : undefined
@@ -182,9 +183,7 @@ export default class TagList extends Component {
         ))}
         {this.overflowNode()}
         {isEditable === 'always' && (
-          <button
-            className="bx--tag-list--edit--button"
-            onClick={this.handleOnIconClick}>
+          <button className="bx--tag-list--edit--button">
             <Icon
               name="edit--glyph"
               className="bx--tag-list--edit--icon"
@@ -194,9 +193,7 @@ export default class TagList extends Component {
           </button>
         )}
         {isEditable === 'on-hover' && this.state.showEditIcon && (
-          <button
-            className="bx--tag-list--edit--button"
-            onClick={this.handleOnIconClick}>
+          <button className="bx--tag-list--edit--button">
             <Icon
               name="edit--glyph"
               className="bx--tag-list--edit--icon"


### PR DESCRIPTION
Per Design request, allow a user to click anywhere on the tag list and it will open up the edit tag modal.

https://github.ibm.com/Bluemix/core-unified-console/issues/1276#event-42091810