### PR TITLE
feat: added class name to tooltip for css style (#1303)

### DIFF
--- a/src/components/TagList/TagList.js
+++ b/src/components/TagList/TagList.js
@@ -118,7 +118,11 @@ export default class TagList extends Component {
       );
       const tooltipOverflowCount = tags.length - totalTagsDisplayed;
       overflowCountNode = (
-        <Tooltip showIcon={false} triggerText={overflowCountNode} tabIndex={0}>
+        <Tooltip
+          className="bx--cell--tooltip"
+          showIcon={false}
+          triggerText={overflowCountNode}
+          tabIndex={0}>
           {overflowTagsNode}
           {tooltipOverflowCount === 0 ? (
             undefined


### PR DESCRIPTION
This new class name will be used for css styling and apply a black carbon tooltip on Resource Explorer.