### PR TITLE
style: changed ellipsis format (#1317)

### DIFF
--- a/src/components/Tag/Tag-test.js
+++ b/src/components/Tag/Tag-test.js
@@ -37,7 +37,7 @@ describe('Tag', () => {
     expect(tag.hasClass('extra-class')).toEqual(true);
   });
 
-  it('should shorten non-key:value tags to max 10 characters if set', () => {
+  it('should shorten tags to max 10 characters if set', () => {
     const tag = shallow(
       <Tag
         type="functional"
@@ -47,19 +47,6 @@ describe('Tag', () => {
       />
     );
     expect(tag.text()).toEqual('tag test l...');
-    expect(tag.text().replace('...', '').length).toBeLessThan(11);
-  });
-
-  it('should shorten key:value tags to max 10 characters if set', () => {
-    const tag = shallow(
-      <Tag
-        type="functional"
-        className="extra-class"
-        maxCharacters={10}
-        children={'acct:costCtr'}
-      />
-    );
-    expect(tag.text()).toEqual('acct:...stCtr');
     expect(tag.text().replace('...', '').length).toBeLessThan(11);
   });
 });

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -55,20 +55,8 @@ export default class Tag extends Component {
       maxCharacters &&
       children.length > maxCharacters
     ) {
-      // if tag is key:value pair
-      if (children.indexOf(':') !== -1) {
-        // grab trimmed first and last half
-        const beginning = children.substring(0, maxCharacters / 2).trim();
-        const end = children
-          .substring(children.length - maxCharacters / 2)
-          .trim();
-
-        shortenedName = beginning + '...' + end;
-      } else {
-        // if not key:value pair
-        const shorten = children.substring(0, maxCharacters).trim();
-        shortenedName = shorten + '...';
-      }
+      const shorten = children.substring(0, maxCharacters).trim();
+      shortenedName = shorten + '...';
     }
     const tagClasses = classNames({
       'bx--tag': true,

--- a/src/components/Tooltip/MouseOverTooltip-test.js
+++ b/src/components/Tooltip/MouseOverTooltip-test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import debounce from 'lodash.debounce';
+import debounce from 'lodash/debounce';
 import { iconInfoGlyph } from 'carbon-icons';
 import { Icon } from 'carbon-components-react';
 import MouseOverTooltip from '../Tooltip';
 import { shallow, mount } from 'enzyme';
 
-jest.mock('lodash.debounce');
+jest.mock('lodash/debounce');
 
 const mockCancel = jest.fn();
 debounce.mockImplementation(fn =>

--- a/src/components/Tooltip/MouseOverTooltip.js
+++ b/src/components/Tooltip/MouseOverTooltip.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import debounce from 'lodash.debounce';
+import debounce from 'lodash/debounce';
 import { Tooltip } from 'carbon-components-react';
 
 export default class MouseOverTooltip extends Tooltip {


### PR DESCRIPTION
Before tags that were key:value were formatted differently, they had the ellipsis (...) in the middle.  Now these tags are no longer treated differently, now treated as normal tags so the ellipsis will be at the end for all tags.