### PR TITLE
fix(filters): allow customize tooltip and fix accessibility

### DIFF
--- a/src/components/Checkbox/Checkbox-test.js
+++ b/src/components/Checkbox/Checkbox-test.js
@@ -107,7 +107,7 @@ describe('Checkbox', () => {
     wrapper.setProps({ hasGroups: true });
     wrapper.update();
 
-    expect(wrapper.find('MouseOverTooltip').prop('tabIndex')).toEqual(0);
+    expect(wrapper.find('MouseOverTooltip').prop('tabIndex')).toEqual(-1);
     expect(wrapper.find('CheckBoxIcon').exists()).toBe(true);
   });
 

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -59,7 +59,7 @@ const Checkbox = ({
               <MouseOverTooltip
                 className="bx--checkbox--tooltip"
                 showIcon={false}
-                tabIndex={hasGroups ? 0 : -1}
+                tabIndex={-1}
                 triggerText={labelText}>
                 {tooltipText}
               </MouseOverTooltip>

--- a/src/components/MultiSelect/__tests__/__snapshots__/NestedFilterableMultiselect-test.js.snap
+++ b/src/components/MultiSelect/__tests__/__snapshots__/NestedFilterableMultiselect-test.js.snap
@@ -40,6 +40,7 @@ exports[`NestedFilterableMultiselect Simple multiselect should render 1`] = `
   locale="en"
   onChange={[MockFunction]}
   placeholder="Placeholder..."
+  showTooltip={true}
   sortItems={[Function]}
 >
   <Selection
@@ -195,6 +196,202 @@ exports[`NestedFilterableMultiselect Simple multiselect should render 1`] = `
 </NestedFilterableMultiselect>
 `;
 
+exports[`NestedFilterableMultiselect Simple multiselect should render without showing tooltip 1`] = `
+<NestedFilterableMultiselect
+  compareItems={[Function]}
+  disabled={false}
+  filterItems={[Function]}
+  initialSelectedItems={Array []}
+  itemToString={[Function]}
+  items={
+    Array [
+      Object {
+        "id": "id-0",
+        "label": "Item 0",
+        "value": 0,
+      },
+      Object {
+        "id": "id-1",
+        "label": "Item 1",
+        "value": 1,
+      },
+      Object {
+        "id": "id-2",
+        "label": "Item 2",
+        "value": 2,
+      },
+      Object {
+        "id": "id-3",
+        "label": "Item 3",
+        "value": 3,
+      },
+      Object {
+        "id": "id-4",
+        "label": "Item 4",
+        "value": 4,
+      },
+    ]
+  }
+  light={false}
+  locale="en"
+  onChange={[MockFunction]}
+  placeholder="Placeholder..."
+  showTooltip={false}
+  sortItems={[Function]}
+>
+  <Selection
+    initialSelectedItems={Array []}
+    onChange={[Function]}
+    render={[Function]}
+  >
+    <Downshift
+      breakingChanges={Object {}}
+      defaultHighlightedIndex={null}
+      defaultInputValue=""
+      defaultIsOpen={false}
+      defaultSelectedItem={null}
+      environment={[Window]}
+      getA11yStatusMessage={[Function]}
+      highlightedIndex={null}
+      inputValue=""
+      isOpen={false}
+      itemToString={[Function]}
+      onChange={[Function]}
+      onInputValueChange={[Function]}
+      onOuterClick={[Function]}
+      onSelect={[Function]}
+      onStateChange={[Function]}
+      onUserAction={[Function]}
+      render={[Function]}
+      selectedItem={Array []}
+      selectedItemChanged={[Function]}
+      stateReducer={[Function]}
+    >
+      <ListBox
+        ariaLabel="Choose an item"
+        className="bx--multi-select bx--combo-box"
+        disabled={false}
+        innerRef={[Function]}
+        type="default"
+      >
+        <div
+          aria-label="Choose an item"
+          className="bx--multi-select bx--combo-box bx--list-box"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="listbox"
+        >
+          <ListBoxField
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="open menu"
+            data-toggle={true}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex="-1"
+            type="button"
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="open menu"
+              className="bx--list-box__field"
+              data-toggle={true}
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex="-1"
+              type="button"
+            >
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-expanded={false}
+                aria-label="Placeholder..."
+                autoComplete="off"
+                className="bx--text-input"
+                disabled={false}
+                id="downshift-1-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                placeholder="Placeholder..."
+                role="combobox"
+                value=""
+              />
+              <ListBoxMenuIcon
+                isOpen={false}
+                translateWithId={[Function]}
+              >
+                <div
+                  className="bx--list-box__menu-icon"
+                >
+                  <Icon
+                    alt="Open menu"
+                    description="Open menu"
+                    fillRule="evenodd"
+                    icon={
+                      Object {
+                        "height": "5",
+                        "id": "icon--caret--down",
+                        "name": "icon--caret--down",
+                        "styles": "",
+                        "svgData": Object {
+                          "circles": "",
+                          "ellipses": "",
+                          "paths": Array [
+                            Object {
+                              "d": "M0 0l5 4.998L10 0z",
+                            },
+                          ],
+                          "polygons": "",
+                          "polylines": "",
+                          "rects": "",
+                        },
+                        "tags": "icon--caret--down",
+                        "viewBox": "0 0 10 5",
+                        "width": "10",
+                      }
+                    }
+                    name="icon--caret--down"
+                    role="img"
+                  >
+                    <svg
+                      alt="Open menu"
+                      aria-label="Open menu"
+                      fillRule="evenodd"
+                      height="5"
+                      name="icon--caret--down"
+                      role="img"
+                      viewBox="0 0 10 5"
+                      width="10"
+                    >
+                      <title>
+                        Open menu
+                      </title>
+                      <path
+                        d="M0 0l5 4.998L10 0z"
+                        key="key0"
+                      />
+                    </svg>
+                  </Icon>
+                </div>
+              </ListBoxMenuIcon>
+            </div>
+          </ListBoxField>
+        </div>
+      </ListBox>
+    </Downshift>
+  </Selection>
+</NestedFilterableMultiselect>
+`;
+
 exports[`NestedFilterableMultiselect multiselect with categories should render 1`] = `
 <NestedFilterableMultiselect
   compareItems={[Function]}
@@ -241,6 +438,7 @@ exports[`NestedFilterableMultiselect multiselect with categories should render 1
   locale="en"
   onChange={[MockFunction]}
   placeholder="Placeholder..."
+  showTooltip={true}
   sortItems={[Function]}
 >
   <Selection
@@ -459,6 +657,7 @@ exports[`NestedFilterableMultiselect multiselect with suboptions should render 1
   locale="en"
   onChange={[MockFunction]}
   placeholder="Placeholder..."
+  showTooltip={true}
   sortItems={[Function]}
 >
   <Selection

--- a/src/components/Tooltip/MouseOverTooltip-test.js
+++ b/src/components/Tooltip/MouseOverTooltip-test.js
@@ -75,7 +75,7 @@ describe('Tooltip', () => {
       const wrapper = mount(
         <MouseOverTooltip showIcon={false} triggerText="Tooltip" />
       );
-      const trigger = wrapper.find('.bx--tooltip__trigger');
+      const trigger = wrapper.find('.bx--tooltip__label');
       trigger.simulate('mouseover');
       expect(wrapper.state().open).toEqual(true);
       trigger.simulate('mouseout');
@@ -86,7 +86,7 @@ describe('Tooltip', () => {
       const wrapper = mount(
         <MouseOverTooltip showIcon={false} triggerText="Tooltip" />
       );
-      const trigger = wrapper.find('.bx--tooltip__trigger');
+      const trigger = wrapper.find('.bx--tooltip__label');
       trigger.simulate('mouseover');
       expect(wrapper.state().open).toEqual(true);
       trigger.simulate('focus');
@@ -97,7 +97,7 @@ describe('Tooltip', () => {
       const wrapper = mount(
         <MouseOverTooltip showIcon={false} triggerText="Tooltip" />
       );
-      const trigger = wrapper.find('.bx--tooltip__trigger');
+      const trigger = wrapper.find('.bx--tooltip__label');
       trigger.simulate('mouseover');
       expect(wrapper.state().open).toEqual(true);
       trigger.simulate('blur');
@@ -108,7 +108,7 @@ describe('Tooltip', () => {
       const wrapper = mount(
         <MouseOverTooltip showIcon={false} triggerText="Tooltip" />
       );
-      const trigger = wrapper.find('.bx--tooltip__trigger');
+      const trigger = wrapper.find('.bx--tooltip__label');
       trigger.simulate('mouseover');
       expect(wrapper.state().open).toEqual(true);
       const tooltip = wrapper.find('FloatingMenu');


### PR DESCRIPTION
This PR does the following:

1) Add a new flag to customize showing the tooltip or not
2) Update the component to make it behave the same as https://github.com/IBM/carbon-components-react/blob/master/src/components/MultiSelect/FilterableMultiSelect.js in terms of accessibility.