### PR TITLE
feat(InteriorLeftNav): default active href prop

### DIFF
--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -11,6 +11,7 @@ export default class InteriorLeftNav extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     activeHref: PropTypes.string,
+    defaultActiveHref: PropTypes.string,
     onToggle: PropTypes.func,
   };
 
@@ -20,7 +21,7 @@ export default class InteriorLeftNav extends Component {
 
   state = {
     activeHref:
-      this.props.activeHref || (window.location && window.location.pathname),
+      this.props.activeHref || this.props.defaultActiveHref || (window.location && window.location.pathname),
     open: true,
   };
 


### PR DESCRIPTION
Currently setting `activeHref` means that any time any prop updates, it resets the internal activeHref to the prop. Because of this, there is no way to set the initial default active href and then let the component's logic take over when items are clicked.
This add `defaultActiveHref` (naming similar to input's `value` vs `defaultValue`) to allow for unmanaged activeHref to be defaulted. It is mostly needed when `window.location.pathname` doesn't work (such as when links have hashes).

#### Changelog

**New**

- add `defaultActiveHref` prop to `InteriorLeftNav`
