### PR TITLE
fix(filters): should inherit fonts from the page instead

### DIFF
--- a/src/components/GroupLabel/GroupLabel.js
+++ b/src/components/GroupLabel/GroupLabel.js
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 const categoryLabel = {
   color: '#5A6872',
   fontSize: '12px',
-  fontFamily: 'ibm plex Sans',
   fontWeight: '600',
   letterSpacing: '0.2px',
   margin: '8px 16px',


### PR DESCRIPTION
Should inherit fonts from the page instead of specifying it on its own.