### PR TITLE
feat(combobox): clone carbon V9 ComboBox to support custom item element

### DIFF
--- a/src/components/ComboBox/ComboBox-test.js
+++ b/src/components/ComboBox/ComboBox-test.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from 'react';
 import { mount } from 'enzyme';
 import {
@@ -11,7 +18,11 @@ import {
 import ComboBox from '../ComboBox';
 
 const findInputNode = wrapper => wrapper.find('.bx--text-input');
-const clearInput = wrapper => wrapper.instance().handleOnInputValueChange('');
+const downshiftActions = {
+  setHighlightedIndex: jest.fn(),
+};
+const clearInput = wrapper =>
+  wrapper.instance().handleOnInputValueChange('', downshiftActions);
 
 describe('ComboBox', () => {
   let mockProps;
@@ -38,6 +49,28 @@ describe('ComboBox', () => {
     findInputNode(wrapper).simulate('click');
 
     assertMenuOpen(wrapper, mockProps);
+  });
+
+  it('should display custom div of an item', () => {
+    const itemToElement = item => {
+      return <div className="custom-div">{item.label}</div>;
+    };
+    const wrapper = mount(
+      <ComboBox {...mockProps} itemToElement={itemToElement} />
+    );
+    findInputNode(wrapper).simulate('click');
+
+    assertMenuOpen(wrapper, mockProps);
+
+    expect(
+      wrapper.containsAllMatchingElements([
+        <div className="custom-div">Item 0</div>,
+        <div className="custom-div">Item 1</div>,
+        <div className="custom-div">Item 2</div>,
+        <div className="custom-div">Item 3</div>,
+        <div className="custom-div">Item 4</div>,
+      ])
+    ).toBe(true);
   });
 
   it('should call `onChange` each time an item is selected', () => {
@@ -132,10 +165,10 @@ describe('ComboBox', () => {
     it('should set `inputValue` to an empty string if a falsey-y value is given', () => {
       const wrapper = mount(<ComboBox {...mockProps} />);
 
-      wrapper.instance().handleOnInputValueChange('foo');
+      wrapper.instance().handleOnInputValueChange('foo', downshiftActions);
       expect(wrapper.state('inputValue')).toBe('foo');
 
-      wrapper.instance().handleOnInputValueChange(null);
+      wrapper.instance().handleOnInputValueChange(null, downshiftActions);
       expect(wrapper.state('inputValue')).toBe('');
     });
   });

--- a/src/components/ComboBox/tools/filter.js
+++ b/src/components/ComboBox/tools/filter.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 export const defaultFilterItems = (items, { itemToString, inputValue }) =>
   items.filter(item => {
     if (!inputValue) {

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@ export CardStatus from './components/CardStatus';
 export * from './components/CloudHeader';
 export { default as CloudHeader } from './components/CloudHeader';
 
+export ComboBox from './components/ComboBox';
+
 export DetailPageHeader from './components/DetailPageHeader';
 
 export InteriorLeftNav from './components/InteriorLeftNav';


### PR DESCRIPTION
This is a direct clone of the ComboBox component in Carbon V9 and add a new property, `itemToElement` which is supported in Carbon 10, to allow customizing the div element for the menu item.