### PR TITLE
fix(tags): tag classes overwrite carbon tag classes

### DIFF
--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -61,6 +61,7 @@ export default class Tag extends Component {
     }
     const tagClasses = classNames({
       'bx--tag': true,
+      'cac--tag': true,
       [`bx--tag--${type}`]: true,
       'bx--tag__removed': this.state.removed,
       [className]: className,
@@ -73,7 +74,7 @@ export default class Tag extends Component {
 
     const closeIcon = (
       <Icon
-        className="bx--tag-close"
+        className="bx--tag-close cac--tag-close"
         icon={iconClose}
         tabIndex="0"
         role="button"


### PR DESCRIPTION
- added additional classes here and at carbon-addons-cloud so that carbon styles do not get overwritten
